### PR TITLE
Oxmysql Update & Auto SQL Fix

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -3,6 +3,7 @@ Config = {}
 Config.Mysql = 'oxmysql' -- mysql-async, ghmattisql, oxmysql
 Config.weight_type = true
 Config.weight = 1.5
+Config.DBName = '' -- Important For Auto SQL Insert. Please put your database name here
 Config.Framework = 'Standalone' -- ESX,QBCORE,Standalone (ITEM PURPOSE ONLY)
 Config.FixedCamera = true
 

--- a/framework/sv_wrapper.lua
+++ b/framework/sv_wrapper.lua
@@ -94,12 +94,12 @@ function SqlFunc(plugin,type,query,var)
         end)
     end
     if type == 'execute' and plugin == 'oxmysql' then
-        exports.oxmysql:query(query, var, function(result)
+        MySQL.Async.execute(query, var, function(result)
             wait:resolve(result)
         end)
     end
     if type == 'fetchAll' and plugin == 'oxmysql' then
-		exports.oxmysql:query(query, var, function(result)
+		MySQL.query(query, var, function(result)
 			wait:resolve(result)
 		end)
     end

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -10,7 +10,8 @@ shared_scripts {
 }
 
 server_scripts {
-	'@mysql-async/lib/MySQL.lua',	
+	'@mysql-async/lib/MySQL.lua',
+	--'@oxmysql/lib/MySQL.lua',
     'framework/sv_wrapper.lua',
 	"server.lua"
 }

--- a/server.lua
+++ b/server.lua
@@ -39,11 +39,16 @@ local sql = setmetatable({},{
 local db = sql()
 
 Citizen.CreateThreadNow(function()
-	local success, result = pcall(MySQL.scalar.await, 'SELECT 1 FROM renzu_stancer')
+    if not Config.DBName or Config.DBName == '' then
+        print('^1[RENZU_STANCER] ^0Please put your database name in config.lua line 6')
+        return
+    end
+    local havedb = MySQL.query.await('SELECT * FROM information_schema.tables WHERE table_schema = ? AND table_name = ?', {Config.DBName, 'renzu_stancer'})
 
-	if not success then
+	if not havedb[1] then
 		MySQL.query.await([[CREATE TABLE `renzu_stancer` (
-			`plate` varchar(128) NOT NULL AUTO_INCREMENT KEY,
+            `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			`plate` varchar(128) NOT NULL,
 			`setting` longtext DEFAULT NULL
 		)]])
 		print("^2SQL INSTALL SUCCESSFULLY ^0")


### PR DESCRIPTION
Adding the newest OxmySQL functions and added auto SQL insert Fix. The old system won't work cause the Protected Call works when the exception is within the same script but the exception was happening in that case in another SQL (oxmysql/MYSQL Wrapper). So it's better to use the information schema table to fetch all tables!